### PR TITLE
Add drush-batcher (originally lived in adhocscripts) and run-drush-migrations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,8 @@
   },
   "bin": [
     "drush",
+    "drush-batcher",
+    "run-drush-migrations",
     "drush.launcher",
     "drush.php",
     "drush.complete.sh"

--- a/drush-batcher
+++ b/drush-batcher
@@ -1,0 +1,49 @@
+#!/bin/bash
+#Run a drush command against all sites in parallel batches
+#eg: drush-batcher.sh -n 20 -x healthmark -x alliancelc -d /var/www/care-planner.co.uk/sites -c "/usr/bin/drush cc all"
+
+bold=$'\e[1m'
+normal=$'\e[0m'
+italic=$'\e[3m'
+
+_usage()
+{
+  cat <<USAGE
+Usage: ${bold}$(basename $0) [-n${normal} ${italic}count${normal}${bold}] [-x${normal} ${italic}exclude1 ${bold}-x${normal} ${italic}exclude2 ${normal}${bold}...] -d${normal} ${italic}targetdir${normal}${bold} -c ${normal}${italic}"command"${normal}
+   eg: $(basename $0) -n 20 -x healthmark -x alliancelc -d /var/www/care-planner.co.uk -c "/usr/bin/drush cc all"
+USAGE
+}
+
+#always ignore the default drupal site
+EXCLUDE=("default")
+
+while getopts n:x:d:c:h option ; do
+ case ${option} in
+ n) MAXJOBS=${OPTARG};;
+ x) EXCLUDE+=("$OPTARG");;
+ d) SITES_DIR=${OPTARG};;
+ c) COMMAND=${OPTARG};;
+ \?)
+  echo "Invalid option: -$OPTARG" >&2
+  usage
+  exit 1
+  ;;
+ h)
+  usage
+  exit 1
+  ;;
+ esac
+done
+shift $((OPTIND-1))
+
+[ -z "$MAXJOBS" ] && MAXJOBS=10
+[ -z "$SITES_DIR" ] && _usage && exit 1
+[ -z "$COMMAND" ] && _usage && exit 1
+
+SITES=($(find "$SITES_DIR" -mindepth 2 -maxdepth 2 -name settings.php -printf '%h\n' | sed 's!.*/!!'))
+for i in "${SITES[@]}" ; do
+  for j in "${EXCLUDE[@]}" ; do
+    echo "$j"
+  done | grep -q $i || echo $i
+done | parallel -j $MAXJOBS --tag "cd ${SITES_DIR}/{} ; ${COMMAND} ;"
+

--- a/run-drush-migrations
+++ b/run-drush-migrations
@@ -1,0 +1,13 @@
+#!/bin/bash
+#Runs drush-batcher as part of an automatic migration. Entrypoint to the k8s job
+#Always runs updb --y and can optionally run partial or total cache clears
+#eg: run-drush-migrations all / run-drush-migrations css-js
+
+declare -r CLEAR_CACHES=$1
+if [[ -z "$CLEAR_CACHES" ]] ; then
+    COMMAND="drush updb --y"
+else
+    COMMAND="drush updb --y && drush cc $CLEAR_CACHES"
+fi
+
+drush-batcher -c "$COMMAND" 2>&1


### PR DESCRIPTION
Adds `drush-batcher` so we can have it available by default in the webapp. Will be used for running database migrations out of Kubernetes.

Also adds a new script, `run-drush-migrations`, that wraps `drush-batcher` to make it easier to call out of a Kubernetes job.

Related PR that adds the deps and a symlink to the base cp image: https://github.com/CarePlanner/cp-docker/pull/7