### PR TITLE
run-drush-migrations - always exit with a success code

### DIFF
--- a/run-drush-migrations
+++ b/run-drush-migrations
@@ -11,3 +11,8 @@ else
 fi
 
 drush-batcher -c "$COMMAND" 2>&1
+
+# We always want to exit with a success code, as otherwise this can
+# cause the pod and subsequently CI/CD pipeline to "fail" on errors
+# we don't care about. Any errors we do care about will alert to PagerDuty.
+exit 0


### PR DESCRIPTION
`drush-batcher` sometimes exits with an error code for errors we don't care about, e.g:

```
gladwintowers   Directory /root/.drush/cache/default exists, but is not writable.        [error]
gladwintowers   Please check directory permissions.                                                                                                                                                      
gladwintowers   file_put_contents(/root/.drush/cache/default/8.3.1-annotationfiles-5-37b4ca3430eba2dd87bc40d1175f9f7f.cache):  [warning]                                                                 
gladwintowers   failed to open stream: No such file or directory JSONCache.php:22    
```

These cause `run-drush-batcher` to exit with an error code, which causes the pod to enter the "Failed" state, which causes the helm deploy to fail, which causes the CI/CD pipeline to fail.

We have alerting configured for any errors we _do_ care about, so this PR just makes `run-drush-migrations` always exit with a success code.

@slifin for info.